### PR TITLE
Adds custom ingredients method

### DIFF
--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._utils import get_yields
+from ._utils import get_yields, normalize_string
 
 
 class TheCookingGuy(AbstractScraper):
@@ -28,7 +28,9 @@ class TheCookingGuy(AbstractScraper):
         return self.schema.image()
 
     def ingredients(self):
-        return self.schema.ingredients()
+        ingredients = self.soup.find("div", class_="w-layout-vflex card-text-holder ingredients").find_all("li")
+        ingredients_text = [normalize_string(ingredient.get_text()) for ingredient in ingredients]
+        return ingredients_text
 
     def instructions(self):
         return self.schema.instructions()


### PR DESCRIPTION
Resolves #1 

Overview:
- Adds the custom method ingredients to get the ingredients in a recipe from thecookingguy.com

Changes:
'recipe_scrapers/thecookingguy.py'
- adds normalize_string import
- finds all list elements in the div class
- normalizes each string from the list elemets

Testing:
Ran the following commands in the python console and got the expected output of a list of strings representing the ingredient list.
>>> from recipe_scrapers import scrape_me
>>> scraper = scrape_me("https://www.thecookingguy.com/recipes/chili-cumin-lamb")
>>> scraper.ingredients()