### PR TITLE
thecookingguy missing fields

### DIFF
--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 
@@ -14,11 +13,8 @@ class TheCookingGuy(AbstractScraper):
     def title(self):
         return self.schema.title()
 
-    def category(self):
-        return self.schema.category()
-
     def total_time(self):
-        return self.schema.total_time()
+        return None
 
     def yields(self):
         return self.schema.yields()
@@ -31,12 +27,6 @@ class TheCookingGuy(AbstractScraper):
 
     def instructions(self):
         return self.schema.instructions()
-
-    def ratings(self):
-        return self.schema.ratings()
-
-    def cuisine(self):
-        return self.schema.cuisine()
 
     def description(self):
         return self.schema.description()


### PR DESCRIPTION
Resolves https://github.com/rmdluo/recipe-scrapers/issues/3, https://github.com/rmdluo/recipe-scrapers/issues/4, https://github.com/rmdluo/recipe-scrapers/issues/5, and https://github.com/rmdluo/recipe-scrapers/issues/6

Overview:

Returns None for mandatory total_time field since recipe from thecookingguy.com does not provide it and removes missing optional fields from file.
Changes:
'recipe_scrapers/thecookingguy.py'

Returns None for mandatory missing field
Deleted optional field sections

Testing:
Ran the following commands in the python console and got the expected output.

from recipe_scrapers import scrape_me
scraper = scrape_me("https://www.thecookingguy.com/recipes/chili-cumin-lamb")
scraper.ingredients()
Note: optional fields should be excluded from json test as per https://github.com/hhursev/recipe-scrapers/issues/957