### PR TITLE
Thecookingguy refactor ingredient groups

### DIFF
--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -93,7 +93,13 @@ class TheCookingGuy(AbstractScraper):
         return ingredient_groups
 
     def instructions(self):
-        return self.schema.instructions()
+        instructions = self.soup.find(
+            "div", class_="w-layout-vflex card-text-holder directions"
+        ).find_all("li")
+
+        instructions_text = "\n".join(normalize_string(instruction.get_text()) for instruction in instructions)
+        
+        return instructions_text
 
     def description(self):
         return self.schema.description()

--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -43,52 +43,32 @@ class TheCookingGuy(AbstractScraper):
         if ingredients_div is None:
             raise ElementNotFoundInHtml("Ingredients not found.")
 
-        # find all ingredient group purposes
-        ingredient_group_ps = ingredients_div.find_all("p")
-        ingredient_group_ps = [
-            p for p in ingredient_group_ps if p.findChildren("strong")
-        ]
-
-        # find all ingredient lists
-        ungrouped_ingredient_uls = ingredients_div.find_all("ul")
-
-        # create ingredient groups associated with those purposes
-        # skips ungrouped ingredients
+        # initialize ingredient groups with 0th group being ungrouped
         ingredient_groups = []
-        for ingredient_group_p in ingredient_group_ps:
-            ingredients_ul = ingredient_group_p.find_next_sibling()
-            ungrouped_ingredient_uls.remove(
-                ingredients_ul
-            )  # remove list from ungrouped
+        group = IngredientGroup(
+            ingredients=[],
+            purpose=None,
+        )
+        ingredient_groups.append(group)
 
+        for ingredients_ul in ingredients_div.find_all("ul"):
             ingredients = ingredients_ul.find_all("li")
             items = [
                 normalize_string(ingredient.get_text()) for ingredient in ingredients
             ]
-            group = IngredientGroup(
-                ingredients=items,
-                purpose=normalize_string(ingredient_group_p.find("strong").get_text()),
-            )
-            ingredient_groups.append(group)
 
-        # now group ungrouped items into null purpose
-        if len(ungrouped_ingredient_uls) > 0:
-            items = []
+            purpose_p = ingredients_ul.find_previous_sibling()
 
-            for ul in ungrouped_ingredient_uls:
-                ingredients = ul.find_all("li")
-                items.extend(
-                    [
-                        normalize_string(ingredient.get_text())
-                        for ingredient in ingredients
-                    ]
+            if purpose_p and purpose_p.name == "p" and purpose_p.find("strong"):
+                # has purpose, add new group
+                group = IngredientGroup(
+                    ingredients=items,
+                    purpose=normalize_string(purpose_p.find("strong").get_text()),
                 )
-
-            group = IngredientGroup(
-                ingredients=items,
-                purpose=None,
-            )
-            ingredient_groups.append(group)
+                ingredient_groups.append(group)
+            else:
+                # no purpose, add to no purpose group
+                ingredient_groups[0].ingredients.extend(items)
 
         return ingredient_groups
 
@@ -97,8 +77,10 @@ class TheCookingGuy(AbstractScraper):
             "div", class_="w-layout-vflex card-text-holder directions"
         ).find_all("li")
 
-        instructions_text = "\n".join(normalize_string(instruction.get_text()) for instruction in instructions)
-        
+        instructions_text = "\n".join(
+            normalize_string(instruction.get_text()) for instruction in instructions
+        )
+
         return instructions_text
 
     def description(self):

--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -43,13 +43,9 @@ class TheCookingGuy(AbstractScraper):
         if ingredients_div is None:
             raise ElementNotFoundInHtml("Ingredients not found.")
 
-        # initialize ingredient groups with 0th group being ungrouped
+        # initialize ingredient groups
         ingredient_groups = []
-        group = IngredientGroup(
-            ingredients=[],
-            purpose=None,
-        )
-        ingredient_groups.append(group)
+        ungrouped_ingredients = []
 
         for ingredients_ul in ingredients_div.find_all("ul"):
             ingredients = ingredients_ul.find_all("li")
@@ -68,7 +64,14 @@ class TheCookingGuy(AbstractScraper):
                 ingredient_groups.append(group)
             else:
                 # no purpose, add to no purpose group
-                ingredient_groups[0].ingredients.extend(items)
+                ungrouped_ingredients.extend(items)
+
+        if ungrouped_ingredients:
+            group = IngredientGroup(
+                ingredients=ungrouped_ingredients,
+                purpose=None,
+            )
+            ingredient_groups.append(group)
 
         return ingredient_groups
 

--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -67,10 +67,7 @@ class TheCookingGuy(AbstractScraper):
                 ungrouped_ingredients.extend(items)
 
         if ungrouped_ingredients:
-            group = IngredientGroup(
-                ingredients=ungrouped_ingredients,
-                purpose=None,
-            )
+            group = IngredientGroup(ingredients=ungrouped_ingredients, purpose=None)
             ingredient_groups.append(group)
 
         return ingredient_groups


### PR DESCRIPTION
Resolves #15 

Overview:

Refactors the ingredient_groups() method to use find_previous_sibling(). Cuts down on ~20 lines of code.
Changes:
'recipe_scrapers/thecookingguy.py'
 - consolidated both finding grouped and ungrouped ingredients into one for loop

Testing:
Ran the following commands in the python console and got the expected output of a list of strings representing the ingredient group list. Also tested with https://www.thecookingguy.com/recipes/chicken-shawarma.

from recipe_scrapers import scrape_me
scraper = scrape_me("https://www.thecookingguy.com/recipes/chili-cumin-lamb")
scraper.ingredient_groups()